### PR TITLE
Updated documentation to reflect Unhollower 0.3.1.0 or 0.2.0.0

### DIFF
--- a/docs/gettingstarted.md
+++ b/docs/gettingstarted.md
@@ -5,12 +5,13 @@ To use it, you will first need to install it to the desired game.
 
 !> Please note that MelonLoader doesn't do anything on its own. You will have to install some mods to make changes to your game.
 
+!> Also note that there are currently two standards for mods: Unhollower 0.3.1.0, and Unhollower 0.2.0.0. Unhollower 0.2.0.0 is considered **legacy**, and should only be used with mods that haven't been updated.
 # Installation on Il2Cpp games
 ### Automatic Installation
 
 !> This method requires Windows 8 or newer.
 
- - Download the [MelonLoader installation script](https://github.com/Slaynash/MelonLoaderAutoInstaller/releases/download/v1.4.2/MelonLoaderInstaller.bat). We will call it `MelonLoaderInstaller.bat`.
+ - Download the [MelonLoader installation script](https://github.com/thetrueyoshifan/MelonLoaderAutoInstaller/releases/download/1.4.3/MelonLoaderInstaller.bat) or [Melonloader Legacy installation script](https://github.com/Slaynash/MelonLoaderAutoInstaller/releases/download/v1.4.2/MelonLoaderInstaller.bat). We will call it `MelonLoaderInstaller.bat`.
  - Move MelonLoaderInstaller.bat to your game folder, next to your game executable.<br/>
  On steam, you can find the folder by right clicking your game name, clicking `Properties...`, going to the `LOCAL FILES` tab, and pressing the `BROWSE LOCAL FILES...` button.
 
@@ -39,7 +40,7 @@ To use it, you will first need to install it to the desired game.
 - Download <https://github.com/Perfare/Il2CppDumper/releases/download/v6.2.1/Il2CppDumper-v6.2.1.zip>
 - Extract the files to a new folder named `il2cppdumper` in your game directory
 - Download <https://github.com/Slaynash/MelonLoaderAutoInstaller/raw/master/il2cppdumper_config.json> to `<Game/il2cppdumper/config.json` (replace the file)
-- Download <https://github.com/knah/Il2CppAssemblyUnhollower/releases/download/v0.2.0.0/Il2CppAssemblyUnhollower.0.2.0.0.7z>
+- Download <https://github.com/knah/Il2CppAssemblyUnhollower/releases/download/v0.3.1.0/Il2CppAssemblyUnhollower.0.3.1.0.7z> (or <https://github.com/knah/Il2CppAssemblyUnhollower/releases/download/v0.2.0.0/Il2CppAssemblyUnhollower.0.2.0.0.7z> for legacy mods)
 - Extract the files to a new folder named `il2cppassemblyunhollower` in your game directory.<br/>
 At this point, your game hierarchy should looks be like this:
 ```
@@ -69,6 +70,8 @@ cd il2cppdumper
 .\Il2CppDumper.exe ..\GameAssembly.dll ..\BONEWORKS_Data\il2cpp_data\Metadata\global-metadata.dat
 cd ..
 mkdir il2cppassemblyunhollower_output
+.\il2cppassemblyunhollower\AssemblyUnhollower.exe --input=il2cppdumper\DummyDll --output=il2cppassemblyunhollower_output --mscorlib=MelonLoader\Managed\mscorlib.dll
+OR (for legacy mods)
 .\il2cppassemblyunhollower\AssemblyUnhollower.exe il2cppdumper\DummyDll il2cppassemblyunhollower_output MelonLoader\Managed\mscorlib.dll
 robocopy il2cppassemblyunhollower_output MelonLoader\Managed /XC /XN /XO /NFL /NDL /NJH
 ```


### PR DESCRIPTION
This will also work when we're on MelonLoader 0.1.1 and Unhollower 0.4.0.0, with some minor changes. Still waiting on a few more approvals from the BONEWORKS side, but we'll most likely be going with this.