### PR TITLE
Replaced MelonModInfo and MelonModGame by MelonInfo and MelonGame

### DIFF
--- a/docs/modders/quickstart.md
+++ b/docs/modders/quickstart.md
@@ -21,13 +21,13 @@ using MelonLoader;
 [assembly: MelonInfo(typeof(MyMod), "My Mod Name", "version", "Author Name")]
 [assembly: MelonGame("GameStudio", "GameName")]
 ```
-MelonModInfo contains 4 parameters:
+MelonInfo contains 4 parameters:
 - `MyMod`: The main class of your mod. We will talk about it later
 - `My Mod Name`: The name of your mod
 - `version`: The version of the mod. It should respect the [semver format](https://semver.org/) (example: `1.0.0`)
 - `Author Name`: The name of author of the mod
 
-MelonModGame contains 2 parameters:
+MelonGame contains 2 parameters:
 - `GameStudio`: The name of the developer(s) of the game, as defined in the Unity settings.
 - `GameName`: The name of the game, as defined in the Unity settings.
 

--- a/docs/modders/quickstart.md
+++ b/docs/modders/quickstart.md
@@ -18,8 +18,8 @@ To do that, go to the `Properties` directory, and add these two lines to the `As
 ```cs
 using MelonLoader;
 // ...
-[assembly: MelonModInfo(typeof(MyMod), "My Mod Name", "version", "Author Name")]
-[assembly: MelonModGame("GameStudio", "GameName")]
+[assembly: MelonInfo(typeof(MyMod), "My Mod Name", "version", "Author Name")]
+[assembly: MelonGame("GameStudio", "GameName")]
 ```
 MelonModInfo contains 4 parameters:
 - `MyMod`: The main class of your mod. We will talk about it later


### PR DESCRIPTION
In the latests versions of MelonLoader MelonModInfo and MelonModGame are deprecated in favor of MelonInfo and MelonGame.